### PR TITLE
Port Windows TLS fixes to Zig 0.16

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
 
       - run: zig build
       - run: zig build test --summary all

--- a/src/connection.zig
+++ b/src/connection.zig
@@ -10,6 +10,10 @@ const Record = record.Record;
 const cipher = @import("cipher.zig");
 const Cipher = cipher.Cipher;
 const SessionResumption = @import("handshake_client.zig").Options.SessionResumption;
+const Transcript = @import("transcript.zig").Transcript;
+const common = @import("handshake_common.zig");
+const CertificateBuilder = common.CertificateBuilder;
+const CertKeyPair = common.CertKeyPair;
 
 const log = std.log.scoped(.tls);
 
@@ -24,6 +28,7 @@ pub const Connection = struct {
     received_close_notify: bool = false,
     /// Part of the cleartext record returned from next but not yet read by client.
     cleartext_buf: []const u8 = &.{},
+    cleartext_storage: [cipher.max_ciphertext_record_len]u8 = undefined,
 
     session_resumption: ?*SessionResumption = null,
     session_resumption_secret_idx: ?usize = null,
@@ -31,6 +36,9 @@ pub const Connection = struct {
     /// ALPN protocol negotiated during TLS handshake (e.g., "h2", "http/1.1").
     /// Points into static data or the options slice; valid for the connection lifetime.
     alpn_protocol: ?[]const u8 = null,
+    auth: ?*CertKeyPair = null,
+    rng: ?std.Random = null,
+    post_handshake_transcript: ?Transcript = null,
 
     const Self = @This();
 
@@ -90,44 +98,16 @@ pub const Connection = struct {
             const rec = try Record.read(c.input);
             if (rec.protocol_version != .tls_1_2) return error.TlsBadVersion;
 
-            // If provided buffer is not big enough reuse input buffer for
-            // cleartext. `rec.header` and `rec.payload`(ciphertext) are
-            // pointing somewhere in this buffer. Decrypter is first reading
-            // then writing a block, cleartext has less length then ciphertext,
-            // cleartext starts from the beginning of the buffer, so ciphertext
-            // is always ahead of cleartext.
-            const cleartext_buf = if (buffer.len >= rec.payload.len) buffer else @constCast(rec.buffer);
+            // If provided buffer is not big enough use connection-owned
+            // storage so readers backed by constant memory are never mutated.
+            const cleartext_buf = if (buffer.len >= rec.payload.len) buffer else &c.cleartext_storage;
             const content_type, const cleartext = try c.cipher.decrypt(cleartext_buf, rec);
 
             switch (content_type) {
                 .application_data => {},
                 .handshake => {
-                    const handshake_type: proto.Handshake = @enumFromInt(cleartext[0]);
-                    switch (handshake_type) {
-                        .new_session_ticket => {
-                            if (c.session_resumption) |r| {
-                                r.pushTicket(cleartext, c.session_resumption_secret_idx.?) catch {};
-                            }
-                            continue;
-                        },
-                        .key_update => {
-                            if (cleartext.len != 5) return error.TlsDecodeError;
-                            // rfc: Upon receiving a KeyUpdate, the receiver MUST
-                            // update its receiving keys.
-                            try c.cipher.keyUpdateDecrypt();
-                            const key: proto.KeyUpdateRequest = @enumFromInt(cleartext[4]);
-                            switch (key) {
-                                .update_requested => {
-                                    @atomicStore(bool, &c.key_update_requested, true, .monotonic);
-                                },
-                                .update_not_requested => {},
-                                else => return error.TlsIllegalParameter,
-                            }
-                            // this record is handled read next
-                            continue;
-                        },
-                        else => {},
-                    }
+                    try c.handlePostHandshakeMessages(cleartext);
+                    continue;
                 },
                 .alert => {
                     if (cleartext.len < 2) return error.TlsUnexpectedMessage;
@@ -140,6 +120,100 @@ pub const Connection = struct {
             }
             return cleartext;
         }
+    }
+
+    fn handlePostHandshakeMessages(c: *Self, cleartext: []const u8) !void {
+        var off: usize = 0;
+        while (off < cleartext.len) {
+            if (cleartext.len - off < 4) return error.TlsDecodeError;
+            const length = (@as(usize, cleartext[off + 1]) << 16) |
+                (@as(usize, cleartext[off + 2]) << 8) |
+                @as(usize, cleartext[off + 3]);
+            const end = off + 4 + length;
+            if (end > cleartext.len) return error.TlsUnsupportedFragmentedHandshakeMessage;
+
+            const hs_msg = cleartext[off..end];
+            const handshake_type: proto.Handshake = @enumFromInt(hs_msg[0]);
+            switch (handshake_type) {
+                .new_session_ticket => {
+                    if (c.session_resumption) |r| {
+                        if (c.session_resumption_secret_idx) |secret_idx| {
+                            r.pushTicket(hs_msg, secret_idx) catch {};
+                        }
+                    }
+                },
+                .key_update => {
+                    if (hs_msg.len != 5) return error.TlsDecodeError;
+                    // rfc: Upon receiving a KeyUpdate, the receiver MUST update its receiving keys.
+                    try c.cipher.keyUpdateDecrypt();
+                    const key: proto.KeyUpdateRequest = @enumFromInt(hs_msg[4]);
+                    switch (key) {
+                        .update_requested => @atomicStore(bool, &c.key_update_requested, true, .monotonic),
+                        .update_not_requested => {},
+                        else => return error.TlsIllegalParameter,
+                    }
+                },
+                .certificate_request => try c.handlePostHandshakeAuth(hs_msg),
+                else => return error.TlsUnexpectedMessage,
+            }
+            off = end;
+        }
+    }
+
+    fn handlePostHandshakeAuth(c: *Self, cert_request: []const u8) !void {
+        var transcript = c.post_handshake_transcript orelse return error.TlsUnexpectedMessage;
+        const ctx = try certificateRequestContext(cert_request);
+        transcript.update(cert_request);
+
+        if (c.auth) |auth| {
+            const rng = c.rng orelse return error.TlsUnexpectedMessage;
+            const cb: CertificateBuilder = .{
+                .cert_key_pair = auth,
+                .transcript = &transcript,
+                .tls_version = .tls_1_3,
+                .side = .client,
+                .rng = rng,
+                .certificate_request_context = ctx,
+            };
+
+            var cert_buf: [16384]u8 = undefined;
+            var cert_w = record.Writer.init(&cert_buf);
+            try cb.makeCertificate(&cert_w);
+            try c.writePostHandshakeMessage(&transcript, cert_w.buffered());
+
+            var cv_buf: [1024]u8 = undefined;
+            var cv_w = record.Writer.init(&cv_buf);
+            try cb.makeCertificateVerify(&cv_w);
+            try c.writePostHandshakeMessage(&transcript, cv_w.buffered());
+        } else {
+            var cert_buf: [128]u8 = undefined;
+            var cert_w = record.Writer.init(&cert_buf);
+            try cert_w.handshakeRecordHeader(.certificate, ctx.len + 4);
+            try cert_w.byte(@intCast(ctx.len));
+            try cert_w.slice(ctx);
+            try cert_w.int(u24, 0);
+            try c.writePostHandshakeMessage(&transcript, cert_w.buffered());
+        }
+
+        var fin_buf: [128]u8 = undefined;
+        var fin_w = record.Writer.init(&fin_buf);
+        try fin_w.handshakeRecord(.finished, transcript.clientFinishedTls13());
+        try c.writePostHandshakeMessage(&transcript, fin_w.buffered());
+
+        c.post_handshake_transcript = transcript;
+    }
+
+    fn writePostHandshakeMessage(c: *Self, transcript: *Transcript, msg: []const u8) !void {
+        transcript.update(msg);
+        try c.encryptWrite(.handshake, msg);
+    }
+
+    fn certificateRequestContext(cert_request: []const u8) ![]const u8 {
+        var d = record.Decoder.init(.handshake, cert_request);
+        if (try d.decode(proto.Handshake) != .certificate_request) return error.TlsUnexpectedMessage;
+        const length = try d.decode(u24);
+        if (length != d.rest().len) return error.TlsDecodeError;
+        return try d.slice(try d.decode(u8));
     }
 
     pub fn eof(c: *Self) bool {
@@ -460,7 +534,6 @@ test "client/server connection" {
 
     // create ciphers pair
     const cipher_client, const cipher_server = brk: {
-        const Transcript = @import("transcript.zig").Transcript;
         const CipherSuite = @import("cipher.zig").CipherSuite;
         const cipher_suite: CipherSuite = .AES_256_GCM_SHA384;
 

--- a/src/handshake_client.zig
+++ b/src/handshake_client.zig
@@ -9,6 +9,7 @@ const Cipher = @import("cipher.zig").Cipher;
 const CipherSuite = @import("cipher.zig").CipherSuite;
 const cipher_suites = @import("cipher.zig").cipher_suites;
 const max_cleartext_len = @import("cipher.zig").max_cleartext_len;
+const max_ciphertext_record_len = @import("cipher.zig").max_ciphertext_record_len;
 
 const Transcript = @import("transcript.zig").Transcript;
 const record = @import("record.zig");
@@ -238,6 +239,10 @@ pub const Handshake = struct {
     /// ALPN protocol selected by the server, copied into alpn_protocol_buf.
     alpn_protocol: ?[]const u8 = null,
     alpn_protocol_buf: [32]u8 = undefined,
+    /// Transcript snapshot used as the base for TLS 1.3 post-handshake auth.
+    post_handshake_transcript: ?Transcript = null,
+    client_application_traffic_secret: [64]u8 = undefined,
+    client_application_traffic_secret_len: usize = 0,
     // statistics
     max_server_record_len: usize = 0,
     max_server_cleartext_len: usize = 0,
@@ -346,6 +351,7 @@ pub const Handshake = struct {
             try h.readEncryptedServerFlight1(resumption_ticket != null); // server flight 1
             const app_cipher = try h.generateApplicationCipher(opt.key_log_callback);
             try h.makeClientFlight2Tls13(opt.auth, opt.rng); // client flight 2
+            h.savePostHandshakeAuthState(opt.auth);
             h.max_client_record_len = @max(h.max_client_record_len, h.output.end);
             try h.output.flush();
 
@@ -383,6 +389,7 @@ pub const Handshake = struct {
         if (h.tls_version == .tls_1_3) {
             const app_cipher = try h.generateApplicationCipher(opt.key_log_callback);
             try h.makeClientFlight2Tls13(opt.auth, opt.rng);
+            h.savePostHandshakeAuthState(opt.auth);
             h.cipher = app_cipher;
         } else {
             // tls 1.2 specific handshake part
@@ -432,11 +439,29 @@ pub const Handshake = struct {
     /// TLS 1.3 application (client) cipher
     fn generateApplicationCipher(h: *Self, key_log_callback: ?key_log.Callback) !Cipher {
         const application_secret = h.transcript.applicationSecret();
+        h.client_application_traffic_secret_len = h.transcript.hashLength();
+        @memcpy(
+            h.client_application_traffic_secret[0..h.client_application_traffic_secret_len],
+            application_secret.client[0..h.client_application_traffic_secret_len],
+        );
         if (key_log_callback) |cb| {
             cb(key_log.label.server_traffic_secret_0, &h.client_random, application_secret.server);
             cb(key_log.label.client_traffic_secret_0, &h.client_random, application_secret.client);
         }
         return try Cipher.initTls13(h.cipher_suite, application_secret, .client);
+    }
+
+    fn savePostHandshakeAuthState(h: *Self, auth: ?*CertKeyPair) void {
+        if (auth == null) {
+            h.post_handshake_transcript = null;
+            return;
+        }
+
+        var transcript = h.transcript;
+        transcript.setPostHandshakeFinishedKey(
+            h.client_application_traffic_secret[0..h.client_application_traffic_secret_len],
+        );
+        h.post_handshake_transcript = transcript;
     }
 
     fn makeClientHello(h: *Self, opt: Options, resumption_ticket: ?ResumptionTicket) !void {
@@ -476,6 +501,10 @@ pub const Handshake = struct {
         try w.serverName(opt.host);
         if (opt.alpn_protocols.len > 0) {
             try w.alpn(opt.alpn_protocols);
+        }
+        if (tls_versions != .tls_1_2 and opt.auth != null) {
+            try w.enumValue(proto.Extension.post_handshake_auth);
+            try w.int(u16, 0);
         }
         // binder key placeholder
         const binder_pos: ?usize = if (resumption_ticket) |ticket| brk: {
@@ -914,7 +943,8 @@ pub const Handshake = struct {
         {
             const rec = try Record.read(h.input);
             h.max_server_record_len = @max(h.max_server_record_len, rec.buffer.len);
-            const content_type, const server_finished = try h.cipher.decrypt(@constCast(rec.buffer), rec);
+            var cleartext_buf: [max_ciphertext_record_len]u8 = undefined;
+            const content_type, const server_finished = try h.cipher.decrypt(&cleartext_buf, rec);
             if (content_type != .handshake)
                 return error.TlsUnexpectedMessage;
             const expected = record.handshakeHeader(.finished, 12) ++ h.transcript.serverFinishedTls12(&h.master_secret);
@@ -1190,6 +1220,32 @@ test "create client hello" {
     try testing.expectEqualSlices(u8, &expected, actual);
     try testing.expectEqual(152, h.output.unusedCapacityLen());
     try testing.expectEqual(114, expected.len);
+}
+
+test "client hello advertises post-handshake auth with client cert" {
+    var auth: CertKeyPair = undefined;
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    const opt: Options = .{
+        .rng = rng_impl.interface(),
+        .host = "google.com",
+        .root_ca = .empty,
+        .cipher_suites = &[_]CipherSuite{CipherSuite.AES_256_GCM_SHA384},
+        .named_groups = &[_]proto.NamedGroup{.x25519},
+        .auth = &auth,
+        .now = .zero,
+    };
+
+    var buffer: [1024]u8 = undefined;
+    var stream_writer: Io.Writer = .fixed(&buffer);
+    var h = Handshake{
+        .output = &stream_writer,
+        .input = undefined,
+    };
+    try h.initKeys(opt);
+    try h.makeClientHello(opt, null);
+
+    const ext = testu.hexToBytes("00 31 00 00");
+    try testing.expect(mem.indexOf(u8, h.output.buffered(), &ext) != null);
 }
 
 test "client hello size" {

--- a/src/handshake_common.zig
+++ b/src/handshake_common.zig
@@ -195,24 +195,25 @@ pub const CertificateBuilder = struct {
     tls_version: proto.Version = .tls_1_3,
     side: proto.Side = .client,
     rng: std.Random,
+    certificate_request_context: []const u8 = &.{},
 
     pub fn makeCertificate(h: CertificateBuilder, w: *record.Writer) !void {
         const certs = h.cert_key_pair.bundle.bytes.items;
         const certs_count = h.cert_key_pair.bundle.map.size;
 
-        // Differences between tls 1.3 and 1.2
-        // TLS 1.3 has request context in header and extensions for each certificate.
-        // Here we use empty length for each field.
-        // TLS 1.2 don't have these two fields.
-        const request_context, const extensions = if (h.tls_version == .tls_1_3)
-            .{ &[_]u8{0}, &[_]u8{ 0, 0 } }
-        else
-            .{ &[_]u8{}, &[_]u8{} };
+        // TLS 1.3 has a request context in the Certificate header and
+        // extensions for each certificate. TLS 1.2 has neither.
+        const extensions = if (h.tls_version == .tls_1_3) &[_]u8{ 0, 0 } else &[_]u8{};
         const certs_len = certs.len + (3 + extensions.len) * certs_count;
 
-        // Write handshake header
-        try w.handshakeRecordHeader(.certificate, certs_len + request_context.len + 3);
-        try w.slice(request_context);
+        if (h.tls_version == .tls_1_3) {
+            if (h.certificate_request_context.len > std.math.maxInt(u8)) return error.TlsIllegalParameter;
+            try w.handshakeRecordHeader(.certificate, certs_len + h.certificate_request_context.len + 4);
+            try w.byte(@intCast(h.certificate_request_context.len));
+            try w.slice(h.certificate_request_context);
+        } else {
+            try w.handshakeRecordHeader(.certificate, certs_len + 3);
+        }
         try w.int(u24, certs_len);
 
         // Write each certificate

--- a/src/key_log.zig
+++ b/src/key_log.zig
@@ -31,16 +31,20 @@ pub fn init(env: std.process.Environ) Callback {
 }
 
 /// Writes tls keys to the file pointed by SSLKEYLOGFILE environment variable.
-fn callback(label_: []const u8, client_random: []const u8, secret: []const u8) void {
-    const builtin = @import("builtin");
-    const native_os = builtin.os.tag;
-    const file_name: []const u8 = if (native_os == .windows)
-        return
-    else if (native_os == .wasi and !builtin.link_libc)
-        return
-    else
-        environ.getPosix(key_log_file_env) orelse return;
-    fileAppend(file_name, label_, client_random, secret) catch return;
+pub fn callback(label_: []const u8, client_random: []const u8, secret: []const u8) void {
+    const allocator = std.heap.page_allocator;
+    const file_name = environ.getAlloc(allocator, key_log_file_env) catch |err| switch (err) {
+        error.EnvironmentVariableMissing => return,
+        else => {
+            std.debug.print("key_log: SSLKEYLOGFILE lookup error: {s}\n", .{@errorName(err)});
+            return;
+        },
+    };
+    defer allocator.free(file_name);
+
+    fileAppend(file_name, label_, client_random, secret) catch |err| {
+        std.debug.print("key_log: write error: {s}\n", .{@errorName(err)});
+    };
 }
 
 fn fileAppend(file_name: []const u8, label_: []const u8, client_random: []const u8, secret: []const u8) !void {
@@ -53,7 +57,10 @@ fn fileWrite(file_name: []const u8, line: []const u8) !void {
     var threaded: std.Io.Threaded = .init_single_threaded;
     const io = threaded.io();
 
-    var file = try std.Io.Dir.createFileAbsolute(io, file_name, .{ .truncate = false });
+    var file = std.Io.Dir.openFileAbsolute(io, file_name, .{ .mode = .read_write }) catch |err| switch (err) {
+        error.FileNotFound => try std.Io.Dir.createFileAbsolute(io, file_name, .{ .read = true, .truncate = false }),
+        else => return err,
+    };
     defer file.close(io);
     const stat = try file.stat(io);
     try file.writePositionalAll(io, line, stat.size);

--- a/src/root.zig
+++ b/src/root.zig
@@ -41,6 +41,9 @@ pub fn client(input: *Io.Reader, output: *Io.Writer, opt: config.Client) !Connec
         .session_resumption_secret_idx = session_resumption_secret_idx,
         .session_resumption = opt.session_resumption,
         .alpn_protocol = hc.alpn_protocol,
+        .auth = opt.auth,
+        .rng = opt.rng,
+        .post_handshake_transcript = hc.post_handshake_transcript,
     };
 }
 

--- a/src/transcript.zig
+++ b/src/transcript.zig
@@ -138,6 +138,13 @@ pub const Transcript = struct {
         };
     }
 
+    /// Replace the client Finished key for TLS 1.3 post-handshake authentication.
+    pub fn setPostHandshakeFinishedKey(t: *Transcript, secret: []const u8) void {
+        switch (t.tag) {
+            inline else => |h| @field(t, @tagName(h)).setPostHandshakeFinishedKey(secret),
+        }
+    }
+
     pub const Secret = struct {
         client: []const u8,
         server: []const u8,
@@ -371,6 +378,10 @@ fn TranscriptT(comptime Hash: type) type {
             const expanded = hkdfExpandLabel(Hkdf, prk, "finished", "", hash_length);
             Hmac.create(self.buffer[0..hash_length], &self.hash.peek(), &expanded);
             return self.buffer[0..hash_length];
+        }
+
+        fn setPostHandshakeFinishedKey(self: *Self, secret: []const u8) void {
+            self.client_finished_key = hkdfExpandLabel(Hkdf, secret[0..hash_length].*, "finished", "", hash_length);
         }
 
         fn serverFinishedTls13(self: *Self) []const u8 {


### PR DESCRIPTION
## Summary

- Pins CI to Zig 0.16.0 for the main branch migration
- Ports the Windows SSLKEYLOGFILE fix to Zig 0.16 APIs
- Confirms issue #1's reader fix is present and adds a safer TLS 1.2 CBC decrypt buffer path
- Ports TLS 1.3 post-handshake client auth support from the zig-0.15 work to main

Fixes #1
Fixes #2
Fixes #3

## Validation

- `zig build`
- `zig build -Doptimize=ReleaseFast`
- `zig build test --summary all` (`56/57` passed, `1` intentionally skipped)
- `zig build integration --summary all` after generating the existing cert fixtures