### PR TITLE
Add TLS 1.2 compatibility fixes

### DIFF
--- a/src/connection.zig
+++ b/src/connection.zig
@@ -419,6 +419,17 @@ const testing = std.testing;
 const data12 = @import("testdata/tls12.zig");
 const testu = @import("testu.zig");
 
+fn expectEncryptedAlert(server_cipher: *Cipher, encrypted: []const u8, expected: [2]u8) !void {
+    var input: Io.Reader = .fixed(encrypted);
+    var cleartext_buf: [64]u8 = undefined;
+
+    const rec = try Record.read(&input);
+    const content_type, const cleartext = try server_cipher.decrypt(&cleartext_buf, rec);
+    try testing.expectEqual(.alert, content_type);
+    try testing.expectEqualSlices(u8, &expected, cleartext);
+    try testing.expectError(error.EndOfStream, Record.read(&input));
+}
+
 test "encrypt decrypt" {
     const rng_impl: std.Random.IoSource = .{ .io = testing.io };
     const rng = rng_impl.interface();
@@ -494,6 +505,64 @@ test "encrypt decrypt" {
         try testing.expectEqual(4, n);
         try testing.expectEqualStrings("pong", buffer[0..n]);
     }
+}
+
+test "tls 1.2 hello request sends no_renegotiation and continues" {
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    const rng = rng_impl.interface();
+
+    var server_cipher = try Cipher.initTls12(.ECDHE_RSA_WITH_AES_128_CBC_SHA, &data12.key_material, .server, rng);
+    server_cipher.ECDHE_RSA_WITH_AES_128_CBC_SHA.rng = testu.random(0x20);
+
+    var input_buf: [256]u8 = undefined;
+    var input_end: usize = 0;
+    {
+        const hello_request = record.handshakeHeader(.hello_request, 0);
+        const encrypted = try server_cipher.encrypt(input_buf[input_end..], .handshake, &hello_request);
+        input_end += encrypted.len;
+    }
+    {
+        const encrypted = try server_cipher.encrypt(input_buf[input_end..], .application_data, "pong");
+        input_end += encrypted.len;
+    }
+
+    var output_buf: [128]u8 = undefined;
+    var stream_reader: Io.Reader = .fixed(input_buf[0..input_end]);
+    var stream_writer: Io.Writer = .fixed(&output_buf);
+    var conn: Connection = .{
+        .input = &stream_reader,
+        .output = &stream_writer,
+        .cipher = try Cipher.initTls12(.ECDHE_RSA_WITH_AES_128_CBC_SHA, &data12.key_material, .client, rng),
+    };
+    conn.cipher.ECDHE_RSA_WITH_AES_128_CBC_SHA.rng = testu.random(0x80);
+
+    try testing.expectEqualStrings("pong", (try conn.next()).?);
+    try expectEncryptedAlert(&server_cipher, stream_writer.buffered(), proto.Alert.noRenegotiation());
+}
+
+test "tls 1.2 malformed hello request sends fatal decode error" {
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    const rng = rng_impl.interface();
+
+    var server_cipher = try Cipher.initTls12(.ECDHE_RSA_WITH_AES_128_CBC_SHA, &data12.key_material, .server, rng);
+    server_cipher.ECDHE_RSA_WITH_AES_128_CBC_SHA.rng = testu.random(0x20);
+
+    var input_buf: [128]u8 = undefined;
+    const malformed_hello_request = record.handshakeHeader(.hello_request, 1) ++ [_]u8{0};
+    const encrypted = try server_cipher.encrypt(&input_buf, .handshake, &malformed_hello_request);
+
+    var output_buf: [128]u8 = undefined;
+    var stream_reader: Io.Reader = .fixed(encrypted);
+    var stream_writer: Io.Writer = .fixed(&output_buf);
+    var conn: Connection = .{
+        .input = &stream_reader,
+        .output = &stream_writer,
+        .cipher = try Cipher.initTls12(.ECDHE_RSA_WITH_AES_128_CBC_SHA, &data12.key_material, .client, rng),
+    };
+    conn.cipher.ECDHE_RSA_WITH_AES_128_CBC_SHA.rng = testu.random(0x80);
+
+    try testing.expectError(error.TlsDecodeError, conn.next());
+    try expectEncryptedAlert(&server_cipher, stream_writer.buffered(), proto.alertFromError(error.TlsDecodeError));
 }
 
 test "post-handshake auth without client certificate sends empty certificate" {

--- a/src/handshake_client.zig
+++ b/src/handshake_client.zig
@@ -1414,6 +1414,54 @@ test "client hello advertises status request" {
     try testing.expect(h.status_request_advertised);
 }
 
+test "client hello advertises secure renegotiation for tls 1.3 capable clients" {
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    const opt: Options = .{
+        .rng = rng_impl.interface(),
+        .host = "google.com",
+        .root_ca = .empty,
+        .cipher_suites = &[_]CipherSuite{CipherSuite.AES_256_GCM_SHA384},
+        .named_groups = &[_]proto.NamedGroup{.x25519},
+        .now = .zero,
+    };
+
+    var buffer: [1024]u8 = undefined;
+    var stream_writer: Io.Writer = .fixed(&buffer);
+    var h = Handshake{
+        .output = &stream_writer,
+        .input = undefined,
+    };
+    try h.initKeys(opt);
+    try h.makeClientHello(opt, null);
+
+    const ext = testu.hexToBytes("ff 01 00 01 00");
+    try testing.expect(mem.indexOf(u8, h.output.buffered(), &ext) != null);
+}
+
+test "client hello advertises secure renegotiation for tls 1.2 only clients" {
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    const opt: Options = .{
+        .rng = rng_impl.interface(),
+        .host = "google.com",
+        .root_ca = .empty,
+        .cipher_suites = &[_]CipherSuite{CipherSuite.ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+        .named_groups = &[_]proto.NamedGroup{.x25519},
+        .now = .zero,
+    };
+
+    var buffer: [1024]u8 = undefined;
+    var stream_writer: Io.Writer = .fixed(&buffer);
+    var h = Handshake{
+        .output = &stream_writer,
+        .input = undefined,
+    };
+    try h.initKeys(opt);
+    try h.makeClientHello(opt, null);
+
+    const ext = testu.hexToBytes("ff 01 00 01 00");
+    try testing.expect(mem.indexOf(u8, h.output.buffered(), &ext) != null);
+}
+
 test "client hello advertises post-handshake auth with client cert" {
     var auth: CertKeyPair = undefined;
     const rng_impl: std.Random.IoSource = .{ .io = testing.io };

--- a/src/handshake_client.zig
+++ b/src/handshake_client.zig
@@ -1009,11 +1009,17 @@ pub const Handshake = struct {
     }
 
     fn readServerFlight2(h: *Self) !void {
-        // Read server change cipher spec message.
-        {
+        // Read optional TLS 1.2 NewSessionTicket messages, then server change cipher spec.
+        while (true) {
             var d = try Record.decoder(h.input);
-            try d.expectContentType(.change_cipher_spec);
             h.max_server_record_len = @max(h.max_server_record_len, d.payload.len + record.header_len);
+
+            switch (d.content_type) {
+                .change_cipher_spec => break,
+                .handshake => try h.readServerFlight2Handshake(&d),
+                .alert => try d.raiseAlert(),
+                else => return error.TlsUnexpectedMessage,
+            }
         }
         // Read encrypted server handshake finished message. Verify that
         // content of the server finished message is based on transcript
@@ -1029,6 +1035,31 @@ pub const Handshake = struct {
             if (!mem.eql(u8, server_finished, &expected))
                 return error.TlsBadRecordMac;
         }
+    }
+
+    fn readServerFlight2Handshake(h: *Self, d: *record.Decoder) !void {
+        h.transcript.update(d.payload);
+
+        while (!d.eof()) {
+            const handshake_type = try d.decode(proto.Handshake);
+            const length = try d.decode(u24);
+            if (length > d.rest().len) return error.TlsUnsupportedFragmentedHandshakeMessage;
+
+            switch (handshake_type) {
+                .new_session_ticket => try parseTls12NewSessionTicket(d, length),
+                else => return error.TlsUnexpectedMessage,
+            }
+        }
+    }
+
+    fn parseTls12NewSessionTicket(d: *record.Decoder, length: u24) !void {
+        if (length < 6) return error.TlsDecodeError;
+
+        const end = d.idx + @as(usize, length);
+        _ = try d.decode(u32); // ticket_lifetime_hint
+        const ticket_len = try d.decode(u16);
+        if (ticket_len != end - d.idx) return error.TlsDecodeError;
+        try d.skip(ticket_len);
     }
 
     /// Write encrypted handshake message into `w`
@@ -1810,6 +1841,51 @@ test "handshake verify server finished message" {
 
     // check that server verify data matches calculates from hashes of all handshake messages
     h.transcript.update(&data12.client_finished);
+    try h.readServerFlight2();
+}
+
+test "tls 1.2 server flight 2 accepts new session ticket before change cipher spec" {
+    const new_session_ticket =
+        record.header(.handshake, 10) ++
+        record.handshakeHeader(.new_session_ticket, 6) ++
+        [_]u8{ 0, 0, 0, 0, 0, 0 };
+
+    var h: Handshake = brk: {
+        var output_buffer: [1024]u8 = undefined;
+        var writer: Io.Writer = .fixed(&output_buffer);
+        break :brk .{ .input = undefined, .output = &writer };
+    };
+
+    h.cipher_suite = .ECDHE_RSA_WITH_AES_128_GCM_SHA256;
+    h.master_secret = data12.master_secret;
+
+    for (data12.handshake_messages) |msg| {
+        h.transcript.update(msg[record.header_len..]);
+    }
+    h.transcript.update(&data12.client_finished);
+
+    var server_transcript = h.transcript;
+    server_transcript.update(new_session_ticket[record.header_len..]);
+    const server_finished = record.handshakeHeader(.finished, 12) ++
+        server_transcript.serverFinishedTls12(&h.master_secret);
+
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    const rng = rng_impl.interface();
+
+    var server_cipher = try Cipher.initTls12(h.cipher_suite, &data12.key_material, .server, rng);
+    var encrypted_finished_buf: [max_ciphertext_record_len]u8 = undefined;
+    const encrypted_finished = try server_cipher.encrypt(&encrypted_finished_buf, .handshake, &server_finished);
+
+    var input_buffer: [new_session_ticket.len + data12.server_change_cipher_spec.len + max_ciphertext_record_len]u8 = undefined;
+    var input_writer: Io.Writer = .fixed(&input_buffer);
+    try input_writer.writeAll(&new_session_ticket);
+    try input_writer.writeAll(&data12.server_change_cipher_spec);
+    try input_writer.writeAll(encrypted_finished);
+
+    var reader: Io.Reader = .fixed(input_writer.buffered());
+    h.input = &reader;
+    h.cipher = try Cipher.initTls12(h.cipher_suite, &data12.key_material, .client, rng);
+
     try h.readServerFlight2();
 }
 

--- a/src/handshake_client.zig
+++ b/src/handshake_client.zig
@@ -243,6 +243,8 @@ pub const Handshake = struct {
     post_handshake_transcript: ?Transcript = null,
     post_handshake_auth_advertised: bool = false,
     status_request_advertised: bool = false,
+    extended_master_secret_advertised: bool = false,
+    extended_master_secret_negotiated: bool = false,
     client_application_traffic_secret: [64]u8 = undefined,
     client_application_traffic_secret_len: usize = 0,
     // statistics
@@ -366,8 +368,7 @@ pub const Handshake = struct {
         }
 
         // tls 1.2 specific handshake part
-        try h.generateCipher(opt.key_log_callback, opt.rng);
-        try h.makeClientFlight2Tls12(opt.auth, opt.rng); // client flight 2
+        try h.makeClientFlight2Tls12(opt.auth, opt.rng, opt.key_log_callback); // client flight 2
         h.max_client_record_len = @max(h.max_client_record_len, h.output.end);
         try h.output.flush();
         try h.readServerFlight2(); // server flight 2
@@ -395,8 +396,7 @@ pub const Handshake = struct {
             h.cipher = app_cipher;
         } else {
             // tls 1.2 specific handshake part
-            try h.generateCipher(opt.key_log_callback, opt.rng);
-            try h.makeClientFlight2Tls12(opt.auth, opt.rng);
+            try h.makeClientFlight2Tls12(opt.auth, opt.rng, opt.key_log_callback);
         }
     }
 
@@ -407,7 +407,6 @@ pub const Handshake = struct {
 
     /// Prepare key material and generate cipher for TLS 1.2
     fn generateCipher(h: *Self, key_log_callback: ?key_log.Callback, rng: std.Random) !void {
-        try h.verifyCertificateSignatureTls12();
         try h.generateKeyMaterial(key_log_callback);
         h.cipher = try Cipher.initTls12(h.cipher_suite, &h.key_material, .client, rng);
     }
@@ -419,7 +418,11 @@ pub const Handshake = struct {
         else
             &h.rsa_secret.secret;
 
-        h.transcript.masterSecret(&h.master_secret, pre_master_secret, h.client_random, h.server_random);
+        if (h.extended_master_secret_negotiated) {
+            h.transcript.extendedMasterSecret(&h.master_secret, pre_master_secret);
+        } else {
+            h.transcript.masterSecret(&h.master_secret, pre_master_secret, h.client_random, h.server_random);
+        }
         h.transcript.keyMaterial(&h.key_material, &h.master_secret, h.client_random, h.server_random);
 
         if (key_log_callback) |cb| {
@@ -469,6 +472,8 @@ pub const Handshake = struct {
     fn makeClientHello(h: *Self, opt: Options, resumption_ticket: ?ResumptionTicket) !void {
         h.post_handshake_auth_advertised = false;
         h.status_request_advertised = false;
+        h.extended_master_secret_advertised = false;
+        h.extended_master_secret_negotiated = false;
 
         // Prepare data
         const tls_versions = try CipherSuite.versions(opt.cipher_suites);
@@ -504,6 +509,10 @@ pub const Handshake = struct {
         }
         try w.statusRequest();
         h.status_request_advertised = true;
+        if (tls_versions != .tls_1_3) {
+            try w.emptyExtension(.extended_master_secret);
+            h.extended_master_secret_advertised = true;
+        }
         if (tls_versions != .tls_1_2) {
             try w.extension(.supported_versions, supported_versions);
         }
@@ -527,7 +536,6 @@ pub const Handshake = struct {
         if (tls_versions != .tls_1_2) {
             try w.emptyExtension(.post_handshake_auth);
             h.post_handshake_auth_advertised = true;
-            try w.emptyExtension(.extended_master_secret);
             try w.emptyRenegotiationInfo();
             if (resumption_ticket == null) {
                 try w.extension(.psk_key_exchange_modes, &[_]proto.KeyExchangeModes{.psk_dhe_ke});
@@ -644,6 +652,7 @@ pub const Handshake = struct {
 
     /// Parse server hello message.
     fn parseServerHello(h: *Self, d: *record.Decoder, length: u24) !void {
+        h.extended_master_secret_negotiated = false;
         if (try d.decode(proto.Version) != proto.Version.tls_1_2)
             return error.TlsBadVersion;
         h.server_random = try d.array(32);
@@ -693,12 +702,19 @@ pub const Handshake = struct {
                     .pre_shared_key => {
                         h.pre_shared_selected_identity = try d.decode(u16);
                     },
+                    .extended_master_secret => {
+                        if (len != 0) return error.TlsIllegalParameter;
+                        if (!h.extended_master_secret_advertised) return error.TlsUnsupportedExtension;
+                        h.extended_master_secret_negotiated = true;
+                    },
                     else => {
                         try d.skip(len);
                     },
                 }
             }
         }
+        if (h.extended_master_secret_negotiated and h.tls_version != .tls_1_2)
+            return error.TlsUnsupportedExtension;
     }
 
     fn isServerHelloRetryRequest(server_random: []const u8) bool {
@@ -866,7 +882,14 @@ pub const Handshake = struct {
     /// finished messages for tls 1.2.
     /// If client certificate is requested also adds client certificate and
     /// certificate verify messages.
-    fn makeClientFlight2Tls12(h: *Self, auth: ?*CertKeyPair, rng: std.Random) !void {
+    fn makeClientFlight2Tls12(
+        h: *Self,
+        auth: ?*CertKeyPair,
+        rng: std.Random,
+        key_log_callback: ?key_log.Callback,
+    ) !void {
+        try h.verifyCertificateSignatureTls12();
+
         var w: record.Writer = .initFromIo(h.output);
         var cert_builder: ?CertificateBuilder = null;
 
@@ -904,6 +927,8 @@ pub const Handshake = struct {
             h.transcript.update(hw.buffered());
             try w.record(.handshake, hw.buffered());
         }
+
+        try h.generateCipher(key_log_callback, rng);
 
         // Client certificate verify
         if (cert_builder) |cb| {
@@ -1058,6 +1083,19 @@ const data12 = @import("testdata/tls12.zig");
 const data13 = @import("testdata/tls13.zig");
 const testu = @import("testu.zig");
 
+fn serverHelloWithExtraExtension(comptime extension_hex: []const u8) [data12.server_hello.len + testu.hexToBytes(extension_hex).len]u8 {
+    const extension = testu.hexToBytes(extension_hex);
+    var server_hello: [data12.server_hello.len + extension.len]u8 = undefined;
+
+    @memcpy(server_hello[0..data12.server_hello.len], &data12.server_hello);
+    @memcpy(server_hello[data12.server_hello.len..], &extension);
+    std.mem.writeInt(u16, server_hello[3..5], std.mem.readInt(u16, data12.server_hello[3..5], .big) + extension.len, .big);
+    std.mem.writeInt(u24, server_hello[6..9], std.mem.readInt(u24, data12.server_hello[6..9], .big) + extension.len, .big);
+    std.mem.writeInt(u16, server_hello[47..49], std.mem.readInt(u16, data12.server_hello[47..49], .big) + extension.len, .big);
+
+    return server_hello;
+}
+
 test "parse tls 1.2 server hello" {
     var buffer: [1024]u8 = undefined;
     var writer: Io.Writer = .fixed(&buffer);
@@ -1088,6 +1126,106 @@ test "parse tls 1.2 server hello" {
     try h.generateKeyMaterial(null);
 
     try testing.expectEqualSlices(u8, &data12.key_material, h.key_material[0..data12.key_material.len]);
+}
+
+test "parse tls 1.2 server hello negotiates extended master secret" {
+    const server_hello = serverHelloWithExtraExtension("00 17 00 00");
+    var reader: Io.Reader = .fixed(&server_hello);
+    var d = try Record.decoder(&reader);
+
+    try testing.expectEqual(.server_hello, try d.decode(proto.Handshake));
+    const length = try d.decode(u24);
+
+    var h: Handshake = .{
+        .output = undefined,
+        .input = undefined,
+        .extended_master_secret_advertised = true,
+    };
+    try h.parseServerHello(&d, length);
+
+    try testing.expect(h.extended_master_secret_negotiated);
+    try testing.expectEqual(.tls_1_2, h.tls_version);
+}
+
+test "parse tls 1.2 server hello rejects malformed extended master secret" {
+    const server_hello = serverHelloWithExtraExtension("00 17 00 01 00");
+    var reader: Io.Reader = .fixed(&server_hello);
+    var d = try Record.decoder(&reader);
+
+    try testing.expectEqual(.server_hello, try d.decode(proto.Handshake));
+    const length = try d.decode(u24);
+
+    var h: Handshake = .{
+        .output = undefined,
+        .input = undefined,
+        .extended_master_secret_advertised = true,
+    };
+    try testing.expectError(error.TlsIllegalParameter, h.parseServerHello(&d, length));
+}
+
+test "tls 1.2 extended master secret uses session hash" {
+    const expected_master_secret = testu.hexToBytes(
+        \\ 96 01 43 e1 bc 08 95 e7 2b 36 0f 49 c9 11 32 e4
+        \\ 40 b1 e3 05 9e 6d f2 dd 89 4f fc 61 66 d7 67 c6
+        \\ 32 9b f5 b7 6d 38 3a 24 95 5d bf 03 81 78 e4 b0
+    );
+
+    var h: Handshake = .{
+        .output = undefined,
+        .input = undefined,
+        .client_random = data12.client_random,
+        .server_random = data12.server_random,
+        .cipher_suite = .ECDHE_RSA_WITH_AES_128_CBC_SHA,
+        .named_group = .x25519,
+        .server_pub_key = &data12.server_pub_key,
+        .extended_master_secret_negotiated = true,
+    };
+    h.dh_kp.x25519_kp.secret_key = data12.client_secret;
+    h.transcript.use(h.cipher_suite.hash());
+
+    for (data12.handshake_messages) |msg| {
+        h.transcript.update(msg[record.header_len..]);
+    }
+
+    try h.generateKeyMaterial(null);
+    try testing.expectEqualSlices(u8, &expected_master_secret, &h.master_secret);
+    try testing.expect(!mem.eql(u8, &data12.master_secret, &h.master_secret));
+}
+
+test "tls 1.2 client flight derives extended master secret after client key exchange" {
+    const expected_master_secret = testu.hexToBytes(
+        \\ cf 5f e6 38 4b fb d9 6f 5b 9e f1 18 27 1a 93 2a
+        \\ 86 f9 d1 49 7f ce 31 25 b8 aa e0 2c e2 99 76 44
+        \\ 1d 80 b1 31 b2 f4 f0 bf 19 69 2a 83 f5 ab 28 6b
+    );
+    const server_hello = serverHelloWithExtraExtension("00 17 00 00");
+    const server_hello_responses = server_hello ++
+        data12.server_certificate ++ data12.server_key_exchange ++ data12.server_hello_done;
+
+    var buffer: [1024]u8 = undefined;
+    var writer: Io.Writer = .fixed(&buffer);
+    var reader: Io.Reader = .fixed(&server_hello_responses);
+    var h: Handshake = .{
+        .output = &writer,
+        .input = &reader,
+        .client_random = data12.client_random,
+        .extended_master_secret_advertised = true,
+    };
+    h.dh_kp.x25519_kp = .{
+        .secret_key = data12.client_secret,
+        .public_key = data12.client_key_exchange_for_transcript[record.header_len + 5 ..][0..32].*,
+    };
+    h.cert = .{ .host = "example.ulfheim.net", .skip_verify = true, .root_ca = .empty, .now_sec = 0 };
+    h.transcript.update(data12.client_hello[record.header_len..]);
+
+    try h.readServerFlight1();
+    h.transcript.use(h.cipher_suite.hash());
+    try testing.expect(h.extended_master_secret_negotiated);
+
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    try h.makeClientFlight2Tls12(null, rng_impl.interface(), null);
+
+    try testing.expectEqualSlices(u8, &expected_master_secret, &h.master_secret);
 }
 
 test "tls 1.2 accepts certificate status when advertised" {
@@ -1343,16 +1481,17 @@ test "tls 1.3 certificate status extension is ignored" {
 
 test "create client hello" {
     const expected = testu.hexToBytes(
-        "16 03 03 00 82 " ++ // record header
-            "01 00 00 7e " ++ // handshake header
+        "16 03 03 00 86 " ++ // record header
+            "01 00 00 82 " ++ // handshake header
             "03 03 " ++ // protocol version
             "00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f " ++ // client random
             "00 " ++ // no session id
             "00 02 c0 2b " ++ // cipher suites
             "01 00 " ++ // compression methods
-            "00 53 " ++ // extensions length
+            "00 57 " ++ // extensions length
             "ff 01 00 01 00 " ++ // renegotiation_info extension
             "00 05 00 05 01 00 00 00 00 " ++ // status_request extension
+            "00 17 00 00 " ++ // extended master secret extension
             "00 0d 00 14 00 12 04 03 05 03 08 04 08 05 08 06 08 07 02 01 04 01 05 01 " ++ // signature algorithms extension
             "00 0a 00 08 00 06 00 1d 00 17 00 18 " ++ // named groups extension
             "00 0b 00 02 01 00 " ++ // EC point formats extension
@@ -1385,8 +1524,8 @@ test "create client hello" {
 
     const actual = h.output.buffered();
     try testing.expectEqualSlices(u8, &expected, actual);
-    try testing.expectEqual(131, h.output.unusedCapacityLen());
-    try testing.expectEqual(135, expected.len);
+    try testing.expectEqual(127, h.output.unusedCapacityLen());
+    try testing.expectEqual(139, expected.len);
 }
 
 test "client hello advertises status request" {
@@ -1460,6 +1599,85 @@ test "client hello advertises secure renegotiation for tls 1.2 only clients" {
 
     const ext = testu.hexToBytes("ff 01 00 01 00");
     try testing.expect(mem.indexOf(u8, h.output.buffered(), &ext) != null);
+}
+
+test "client hello advertises extended master secret for tls 1.2 only clients" {
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    const opt: Options = .{
+        .rng = rng_impl.interface(),
+        .host = "google.com",
+        .root_ca = .empty,
+        .cipher_suites = &[_]CipherSuite{CipherSuite.ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+        .named_groups = &[_]proto.NamedGroup{.x25519},
+        .now = .zero,
+    };
+
+    var buffer: [1024]u8 = undefined;
+    var stream_writer: Io.Writer = .fixed(&buffer);
+    var h = Handshake{
+        .output = &stream_writer,
+        .input = undefined,
+    };
+    try h.initKeys(opt);
+    try h.makeClientHello(opt, null);
+
+    const ext = testu.hexToBytes("00 17 00 00");
+    try testing.expect(mem.indexOf(u8, h.output.buffered(), &ext) != null);
+    try testing.expect(h.extended_master_secret_advertised);
+}
+
+test "client hello advertises extended master secret for mixed tls 1.3 and tls 1.2 clients" {
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    const opt: Options = .{
+        .rng = rng_impl.interface(),
+        .host = "google.com",
+        .root_ca = .empty,
+        .cipher_suites = &[_]CipherSuite{
+            CipherSuite.AES_256_GCM_SHA384,
+            CipherSuite.ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+        },
+        .named_groups = &[_]proto.NamedGroup{.x25519},
+        .now = .zero,
+    };
+
+    var buffer: [1024]u8 = undefined;
+    var stream_writer: Io.Writer = .fixed(&buffer);
+    var h = Handshake{
+        .output = &stream_writer,
+        .input = undefined,
+    };
+    try h.initKeys(opt);
+    try h.makeClientHello(opt, null);
+
+    const ext = testu.hexToBytes("00 17 00 00");
+    try testing.expect(mem.indexOf(u8, h.output.buffered(), &ext) != null);
+    try testing.expect(h.extended_master_secret_advertised);
+}
+
+test "client hello omits extended master secret for tls 1.3 only clients" {
+    const rng_impl: std.Random.IoSource = .{ .io = testing.io };
+    const opt: Options = .{
+        .rng = rng_impl.interface(),
+        .host = "google.com",
+        .root_ca = .empty,
+        .cipher_suites = &[_]CipherSuite{CipherSuite.AES_256_GCM_SHA384},
+        .named_groups = &[_]proto.NamedGroup{.x25519},
+        .now = .zero,
+    };
+
+    var buffer: [1024]u8 = undefined;
+    var stream_writer: Io.Writer = .fixed(&buffer);
+    var h = Handshake{
+        .output = &stream_writer,
+        .input = undefined,
+        .extended_master_secret_advertised = true,
+    };
+    try h.initKeys(opt);
+    try h.makeClientHello(opt, null);
+
+    const ext = testu.hexToBytes("00 17 00 00");
+    try testing.expect(mem.indexOf(u8, h.output.buffered(), &ext) == null);
+    try testing.expect(!h.extended_master_secret_advertised);
 }
 
 test "client hello advertises post-handshake auth with client cert" {
@@ -1747,14 +1965,14 @@ test "nonblock handshake" {
     }
 
     const expected_client_flight_1 = testu.hexToBytes(
-        \\ 16 03 03 00 c2
-        \\ 01 00 00 be
+        \\ 16 03 03 00 be
+        \\ 01 00 00 ba
         \\ 03 03
         \\ 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f
         \\ 00
         \\ 00 02 13 02
         \\ 01 00
-        \\ 00 93
+        \\ 00 8f
         \\ 00 05 00 05 01 00 00 00 00
         \\ 00 2b 00 03 02 03 04
         \\ 00 0d 00 14 00 12 04 03 05 03 08 04 08 05 08 06 08 07 02 01 04 01 05 01
@@ -1765,7 +1983,6 @@ test "nonblock handshake" {
         \\ 35 80 72 d6 36 58 80 d1 ae ea 32 9a df 91 21 38 38 51 ed 21 a2 8e 3b 75 e9 65 d0 d2 cd 16 62 54
         \\ 00 00 00 18 00 16 00 00 13 65 78 61 6d 70 6c 65 2e 75 6c 66 68 65 69 6d 2e 6e 65 74
         \\ 00 31 00 00
-        \\ 00 17 00 00
         \\ ff 01 00 01 00
         \\ 00 2d 00 02 01 01
     );

--- a/src/record.zig
+++ b/src/record.zig
@@ -495,6 +495,19 @@ test "status_request extension writer" {
     );
 }
 
+test "renegotiation_info extension writer" {
+    var buf: [5]u8 = undefined;
+    var w = Writer.init(&buf);
+
+    try w.emptyRenegotiationInfo();
+
+    try testing.expectEqualSlices(
+        u8,
+        &testu.hexToBytes("ff 01 00 01 00"),
+        w.buffered(),
+    );
+}
+
 fn int2(int: u16) [2]u8 {
     var arr: [2]u8 = undefined;
     std.mem.writeInt(u16, &arr, int, .big);

--- a/src/transcript.zig
+++ b/src/transcript.zig
@@ -67,6 +67,19 @@ pub const Transcript = struct {
         }
     }
 
+    pub fn extendedMasterSecret(
+        t: *Transcript,
+        out: []u8,
+        pre_master_secret: []const u8,
+    ) void {
+        switch (t.tag) {
+            inline else => |h| @field(t, @tagName(h)).extendedMasterSecret(
+                out,
+                pre_master_secret,
+            ),
+        }
+    }
+
     pub fn keyMaterial(
         t: *Transcript,
         out: []u8,
@@ -238,6 +251,28 @@ fn TranscriptT(comptime Hash: type) type {
             server_random: [32]u8,
         ) void {
             const seed = "master secret" ++ client_random ++ server_random;
+
+            var a1: [hash_length]u8 = undefined;
+            var a2: [hash_length]u8 = undefined;
+            Hmac.create(&a1, seed, pre_master_secret);
+            Hmac.create(&a2, &a1, pre_master_secret);
+
+            var p1: [hash_length]u8 = undefined;
+            var p2: [hash_length]u8 = undefined;
+            Hmac.create(&p1, a1 ++ seed, pre_master_secret);
+            Hmac.create(&p2, a2 ++ seed, pre_master_secret);
+
+            const master_secret = p1 ++ p2;
+            const len = @min(out.len, master_secret.len);
+            @memcpy(out[0..len], master_secret[0..len]);
+        }
+
+        fn extendedMasterSecret(
+            self: *Self,
+            out: []u8,
+            pre_master_secret: []const u8,
+        ) void {
+            const seed = "extended master secret" ++ self.hash.peek();
 
             var a1: [hash_length]u8 = undefined;
             var a2: [hash_length]u8 = undefined;


### PR DESCRIPTION
## Summary

- Closes #7 by consistently advertising secure renegotiation support and handling TLS 1.2 HelloRequest renegotiation attempts safely.
- Closes #8 by negotiating TLS 1.2 Extended Master Secret and deriving the RFC 7627 master secret when EMS is selected.
- Fixes the nih.gov interoperability failure by matching the advertised EMS extension with the correct TLS 1.2 key derivation.

## Validation

- `zig build test --summary all`
- `zig build integration --summary all`
- `zig build -Doptimize=ReleaseFast`
- `zig build example_http_get -- nih.gov`
